### PR TITLE
complete the seperation from live to local

### DIFF
--- a/client/src/api/baseURL.js
+++ b/client/src/api/baseURL.js
@@ -7,7 +7,6 @@ const token = cookies.get("covid19Project");
 
 let config; 
 
-console.log(process.env.NODE_ENV);
 const prod = (
   axios.create ({
     baseURL: 'https://home2home-covid.herokuapp.com/',
@@ -22,4 +21,4 @@ const local = (
   })
 );
 
-export default config = process.env.NODE_ENV === 'local' ? local : prod;
+export default config = process.env.NODE_ENV === 'development' ? local : prod;

--- a/server.js
+++ b/server.js
@@ -54,7 +54,6 @@ const home = require('./routes/api/home');
 app.use('/', home);
 // Region End - Routing for Homepage
 
-
 // Connecting to MongoDB
 // Handles local database and live database.
 if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'development') {
@@ -69,9 +68,4 @@ if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'developme
 
 if (process.env.NODE_ENV === 'production') {
   app.use(express.static('client/build'));
-}
-
-// Anything that doesn't match the above, send back index.html
-// app.get('*', (req, res) => {
-//   res.sendFile(path.join(__dirname + '/client/build/index.html'))
-// })
+};


### PR DESCRIPTION
close #80 
- Separated database so there is a testing and live. 
- Handled the URL based on live or development. 
- Removed console.logs
- Removed other code that is unnecessary to heroku
- Changed the proxy back to localhost:8080 as it doesn't have an effect on heroku